### PR TITLE
file pairs are now allowed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 <groupId>io.github.danielfscastro</groupId>
 <artifactId>jtpplugin</artifactId>
-<version>1.0-SNAPSHOT</version>
+<version>1.1-SNAPSHOT</version>
 <packaging>maven-plugin</packaging>
 
 
@@ -26,6 +26,12 @@
       <email>daniel.fs.castro@gmail.com</email>
       <organization>dao</organization>
       <organizationUrl>https://github.com/danielfscastro</organizationUrl>
+    </developer>
+    <developer>
+      <name>Renato Louro</name>
+      <email>louro.renato@gmail.com</email>
+      <organization>Silo</organization>
+      <organizationUrl>https://github.com/renatolouro</organizationUrl>
     </developer>
   </developers>
 
@@ -173,6 +179,9 @@
           </goals>
         </execution>
       </executions>
+      <configuration>
+        <skip>true</skip>
+      </configuration>
     </plugin>
     <plugin>
       <groupId>net.ju-n.maven.plugins</groupId>

--- a/src/main/java/br/com/dfsc/hpsaplugin/JavaFileCopyMojo.java
+++ b/src/main/java/br/com/dfsc/hpsaplugin/JavaFileCopyMojo.java
@@ -11,17 +11,26 @@ import java.io.BufferedWriter;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.List;
 
 @Mojo(name = "copy-java", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class JavaFileCopyMojo extends AbstractMojo {
 
-    @Parameter(property = "source", required = true)
-    private String source;
-
-    @Parameter(property = "destination", required = true)
-    private String destination;
+    @Parameter
+    private List<SourceDestinationPair> files;
 
     public void execute() throws MojoExecutionException {
+
+        if (files == null || files.isEmpty()) {
+            throw new MojoExecutionException("No source/destination pairs provided.");
+        }
+
+        for (SourceDestinationPair pair : files) {
+            processFile(pair.getSource(), pair.getDestination());
+        }
+    }
+
+    private void processFile(String source, String destination) throws MojoExecutionException  {
         try (BufferedReader reader = new BufferedReader(new FileReader(source));
              BufferedWriter writer = new BufferedWriter(new FileWriter(destination))) {
 

--- a/src/main/java/br/com/dfsc/hpsaplugin/SourceDestinationPair.java
+++ b/src/main/java/br/com/dfsc/hpsaplugin/SourceDestinationPair.java
@@ -1,0 +1,23 @@
+package br.com.dfsc.hpsaplugin;
+
+public class SourceDestinationPair {
+    private String source;
+    private String destination;
+
+    // getters e setters
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+}


### PR DESCRIPTION
O plugin passa a aceitar agora pares de arquivos desobrigando a utilização de um único arquivo script.

Ex de Configuração:

```
> <configuration>
>         <files>
>             <file>
>                 <source>caminho/do/arquivo1.java</source>
>                 <destination>caminho/do/script1.jtp</destination>
>             </file>
>             <file>
>                 <source>caminho/do/arquivo2.java</source>
>                 <destination>caminho/do/script2.jtp</destination>
>             </file>
>         </files>
>     </configuration>
```