### PR TITLE
Correção de bug: Falso positivo na identificação de definição de classe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 <groupId>io.github.danielfscastro</groupId>
 <artifactId>jtpplugin</artifactId>
-<version>1.1-SNAPSHOT</version>
+<version>1.2-SNAPSHOT</version>
 <packaging>maven-plugin</packaging>
 
 

--- a/src/main/java/br/com/dfsc/hpsaplugin/JavaFileCopyMojo.java
+++ b/src/main/java/br/com/dfsc/hpsaplugin/JavaFileCopyMojo.java
@@ -47,7 +47,7 @@ public class JavaFileCopyMojo extends AbstractMojo {
                 }
 
                 // Verificar se a linha contém a declaração de uma classe
-                if (line.matches(".*\\bclass\\b.*")) {
+                if (line.trim().startsWith("public class")) {
                     insideClass = true; // Entrando no corpo da classe
                     continue; // Ignorar a linha da declaração da classe
                 }


### PR DESCRIPTION
Antes, para identificar a declaração de uma classe tínhamos:
> `if (line.matches(".*\\bclass\\b.*")){...}`

Isso, como efeito colateral, faz com que linhas assim sejam removidas do jtp por conter a string class:

> `AuthorizationDTO resultRdb = gson.fromJson(String.valueOf(rdbResponse), AuthorizationDTO.class);`
